### PR TITLE
Alterando buildkite por circleci para CI do projeto

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,0 @@
-steps:
-  - label: Example Test
-    command: echo "Hello!"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10.15.0
+    parallelism: 3
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+
+      - run:
+          name: Dependencies
+          command: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      - run:
+          name: Lint
+          command: yarn lint
+
+      - run:
+          name: Test
+          command: yarn test

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
     "prettier"
   ],
   "rules": {
+    "react/jsx-one-expression-per-line": 0,
     "react/display-name": 0,
     "react/prop-types": 0,
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # frontend
 
-[![Build Status](https://badge.buildkite.com/192b4cb2485dc8413258a813f6490604ebb407442c64f4a43f.svg)](https://buildkite.com/catolicasc-social/frontend?branch=master)
+[![CircleCI](https://circleci.com/gh/catolicasc-social/frontend.svg?style=svg)](https://circleci.com/gh/catolicasc-social/frontend)
 
 Aplicação frontend para projeto social de um restaurante popular.
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "scripts": {
     "dev": "next ./src",
     "now-build": "next build ./src && next export ./src -o dist",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "echo 'TODO'"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Não havia necessidade de prosseguir com o [Buildkite](https://buildkite.com), pois não é interessante mexer com AWS agora, subir própria infra e etc...

Com o [CircleCI](https://circleci.com) conseguimos resolver todos os nossos problemas sem mexer com infra.