### PR TITLE
Arrumando bug ao entrar direto pela url /login

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@ module.exports = {
   exportPathMap() {
     return {
       '/': { page: '/login' },
+      '/login': { page: '/login' },
       '/index': { page: '/index' },
       '/products': { page: '/products' }
     };


### PR DESCRIPTION
> https://github.com/catolicasc-social/frontend/issues/46

## Descrição
Ao entrar direto pela url `/login`, a página encontrava erro 404.

## O que foi feito
Adicionado rota `/login` ao arquivo de rotas do projeto.

resolve https://github.com/catolicasc-social/frontend/issues/46