### PR TITLE
Favicon global

### DIFF
--- a/src/layouts/page.js
+++ b/src/layouts/page.js
@@ -1,29 +1,7 @@
-import { Component } from 'react';
-import Head from 'next/head';
-import { NextAuth } from 'next-auth/client';
-
 import Content from './content';
 
-export default class extends Component {
-  static async getInitialProps({ req }) {
-    return {
-      session: await NextAuth.init({ req }),
-      lang: 'pt-br'
-    };
-  }
+const Page = ({ children, title }) => (
+  <Content title={title}>{children}</Content>
+);
 
-  render() {
-    const { children, title } = this.props;
-
-    return (
-      <>
-        <Head>
-          <title>Restaurante Popular</title>
-
-          <link rel="icon" href="../static/logo.png" type="image/png" />
-        </Head>
-        <Content title={title}>{children}</Content>
-      </>
-    );
-  }
-}
+export default Page;

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import App, { Container } from 'next/app';
+import Head from 'next/head';
+// import { NextAuth } from 'next-auth/client';
+
+class MyApp extends App {
+  static async getInitialProps({ Component, ctx }) {
+    let pageProps = {};
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx);
+    }
+
+    return { pageProps };
+  }
+
+  /* static async getInitialProps({ req }) {
+    return {
+      session: await NextAuth.init({ req }),
+      lang: 'pt-br'
+    };
+  } */
+
+  render() {
+    const { Component, pageProps } = this.props;
+
+    return (
+      <Container>
+        <Head>
+          <title>Restaurante Popular</title>
+
+          <link rel="icon" href="/static/logo.png" type="image/png" />
+        </Head>
+        <Component {...pageProps} />
+      </Container>
+    );
+  }
+}
+
+export default MyApp;

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-one-expression-per-line */
 import Router from 'next/router';
 import { Icon } from 'evergreen-ui';
 


### PR DESCRIPTION
> https://github.com/catolicasc-social/frontend/issues/49

## Descrição
Favicon antes era declado dentro de `Page`, por isso em cada página teria que declarar o `Page` para assim criar o `<head>` da página.

## O que foi feito
Adicionado arquivo `_app.js` que é renderizado em cada rota, sendo assim o `<head>` fica genérico e o arquivo não precisa ser declarado, pois o `next.js` já cuida disso com o `_app.js`.

resolve https://github.com/catolicasc-social/frontend/issues/49