### PR TITLE
Removendo config jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
   "jest": {
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/"
-    ],
-    "testMatch": [
-      "**/__tests__/*.test.js?(x)"
     ]
   },
   "husky": {


### PR DESCRIPTION
Os testes não estavam funcionando, não estavam sendo encontrados, removendo o `testMatch` da config do jest os testes começaram a funcionar.