### PR TITLE
Adicionando src/ para coletar dados de cobertura de código

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
   "jest": {
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/"
+    ],
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx}"
     ]
   },
   "babel": {


### PR DESCRIPTION
Adicionando propriedade nas config do jest `collectCoverageFrom` para coletar dados de cobertura de código na pasta src/**, assim garantimos que existem testes nela.