### PR TITLE
Alterando nome da lib react-testing-library para poder dar bump

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,2 +1,2 @@
 import 'jest-dom/extend-expect';
-import 'react-testing-library/cleanup-after-each';
+import '@testing-library/react/cleanup-after-each';

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
+    "@testing-library/react": "^8.0.1",
     "codecov": "^3.5.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.0",
@@ -18,8 +19,7 @@
     "jest": "^24.8.0",
     "jest-dom": "^3.4.0",
     "lint-staged": "^8.1.7",
-    "prettier": "^1.17.1",
-    "react-testing-library": "^7.0.1"
+    "prettier": "^1.17.1"
   },
   "dependencies": {
     "dotenv": "^8.0.0",

--- a/src/components/commons/__tests__/Alert.test.js
+++ b/src/components/commons/__tests__/Alert.test.js
@@ -1,4 +1,4 @@
-import { render } from 'react-testing-library';
+import { render } from '@testing-library/react';
 
 import { Alert } from '../Alert';
 

--- a/src/components/commons/__tests__/Button.test.js
+++ b/src/components/commons/__tests__/Button.test.js
@@ -1,4 +1,4 @@
-import { render, fireEvent } from 'react-testing-library';
+import { render, fireEvent } from '@testing-library/react';
 
 import { Button } from '../Button';
 

--- a/src/components/commons/__tests__/Header.test.js
+++ b/src/components/commons/__tests__/Header.test.js
@@ -1,4 +1,4 @@
-import { render } from 'react-testing-library';
+import { render } from '@testing-library/react';
 
 import Header from '../Header';
 

--- a/src/components/commons/__tests__/Heading.test.js
+++ b/src/components/commons/__tests__/Heading.test.js
@@ -1,4 +1,4 @@
-import { render } from 'react-testing-library';
+import { render } from '@testing-library/react';
 
 import { Heading } from '../Heading';
 

--- a/src/components/commons/__tests__/Input.test.js
+++ b/src/components/commons/__tests__/Input.test.js
@@ -1,4 +1,4 @@
-import { render, act } from 'react-testing-library';
+import { render, act } from '@testing-library/react';
 
 import Input from '../Input';
 

--- a/src/components/commons/__tests__/Modal.test.js
+++ b/src/components/commons/__tests__/Modal.test.js
@@ -1,4 +1,4 @@
-import { render } from 'react-testing-library';
+import { render } from '@testing-library/react';
 
 import Modal from '../Modal';
 

--- a/src/components/commons/__tests__/Pane.test.js
+++ b/src/components/commons/__tests__/Pane.test.js
@@ -1,4 +1,4 @@
-import { render, fireEvent } from 'react-testing-library';
+import { render, fireEvent } from '@testing-library/react';
 
 import { Pane } from '../Pane';
 

--- a/src/components/commons/__tests__/Paragraph.test.js
+++ b/src/components/commons/__tests__/Paragraph.test.js
@@ -1,4 +1,4 @@
-import { render } from 'react-testing-library';
+import { render } from '@testing-library/react';
 
 import { Paragraph } from '../Paragraph';
 

--- a/src/components/commons/__tests__/SearchInput.test.js
+++ b/src/components/commons/__tests__/SearchInput.test.js
@@ -1,4 +1,4 @@
-import { render, act } from 'react-testing-library';
+import { render, act } from '@testing-library/react';
 
 import { SearchInput } from '../SearchInput';
 

--- a/src/components/commons/__tests__/Spinner.test.js
+++ b/src/components/commons/__tests__/Spinner.test.js
@@ -1,4 +1,4 @@
-import { render } from 'react-testing-library';
+import { render } from '@testing-library/react';
 
 import { Spinner } from '../Spinner';
 

--- a/src/components/commons/__tests__/Table.test.js
+++ b/src/components/commons/__tests__/Table.test.js
@@ -1,4 +1,5 @@
-import { render } from 'react-testing-library';
+import { render } from '@testing-library/react';
+
 import Table from '../Table';
 
 const items = [

--- a/src/components/commons/__tests__/Tablist.test.js
+++ b/src/components/commons/__tests__/Tablist.test.js
@@ -1,4 +1,4 @@
-import { render } from 'react-testing-library';
+import { render } from '@testing-library/react';
 
 import { Tablist } from '../Tablist';
 

--- a/src/components/commons/__tests__/Text.test.js
+++ b/src/components/commons/__tests__/Text.test.js
@@ -1,4 +1,4 @@
-import { render } from 'react-testing-library';
+import { render } from '@testing-library/react';
 
 import { Text } from '../Text';
 

--- a/src/components/commons/__tests__/Textarea.test.js
+++ b/src/components/commons/__tests__/Textarea.test.js
@@ -1,4 +1,4 @@
-import { render, act } from 'react-testing-library';
+import { render, act } from '@testing-library/react';
 
 import { Textarea } from '../Textarea';
 

--- a/src/layouts/__tests__/content.test.js
+++ b/src/layouts/__tests__/content.test.js
@@ -1,4 +1,4 @@
-import { render } from 'react-testing-library';
+import { render } from '@testing-library/react';
 
 import Content from '../content';
 

--- a/src/layouts/__tests__/page.test.js
+++ b/src/layouts/__tests__/page.test.js
@@ -1,4 +1,4 @@
-import { render } from 'react-testing-library';
+import { render } from '@testing-library/react';
 
 import Page from '../page';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -786,7 +786,7 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.4.3":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
   integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
@@ -1226,6 +1226,24 @@
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
   integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
+
+"@testing-library/dom@^5.0.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.1.1.tgz#091a30b1ca058080bf432cd1aeb2b7c646022f97"
+  integrity sha512-twpAkqomsI0xeOLehijOAmPxeKvs6+WZC/6/nXD0+HNQupP3OZeZho/PBlNhrGL+8nQWiPjdvmxeyU0tq+hctA==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    pretty-format "^24.8.0"
+    wait-for-expect "^1.2.0"
+
+"@testing-library/react@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-8.0.1.tgz#91c254adf855b13de50020613cb5d3915f9f7875"
+  integrity sha512-N/1pJfhEnNYkGyxuw4xbp03evaS0z/CT8o0QgTfJqGlukAcU15xf9uU1w03NHKZJcU69nOCBAoAkXHtHzYwMbg==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@testing-library/dom" "^5.0.0"
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"
@@ -3284,16 +3302,6 @@ dom-storage@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/dom-storage/-/dom-storage-2.1.0.tgz#00fb868bc9201357ea243c7bcfd3304c1e34ea39"
   integrity sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==
-
-dom-testing-library@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-4.1.1.tgz#615af61bee06db51bd8ecea60c113eba7cb49dda"
-  integrity sha512-PUsG7aY5BJxzulDrOtkksqudRRypcVQF6d4RGAyj9xNwallOFqrNLOyg2QW2mCpFaNVPELX8hBX/wbHQtOto/A==
-  dependencies:
-    "@babel/runtime" "^7.4.3"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    pretty-format "^24.7.0"
-    wait-for-expect "^1.1.1"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -7687,7 +7695,7 @@ prettier@^1.17.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
   integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
 
-pretty-format@^24.0.0, pretty-format@^24.7.0, pretty-format@^24.8.0:
+pretty-format@^24.0.0, pretty-format@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"
   integrity sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==
@@ -8046,14 +8054,6 @@ react-ssr-prepass@1.0.2:
   integrity sha512-m8NKaYzWxifPGvrf9WGo/6WtOG6MNBIs2uNdcdIuQswtlkaV19AiFegwTeyblwoH2XxMcRviFJBvr4OkoTt3nA==
   dependencies:
     object-is "^1.0.1"
-
-react-testing-library@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-7.0.1.tgz#0cf113bb53a78599f018378f6854e91a52dbf205"
-  integrity sha512-doQkM3/xPcIm22x9jgTkGxU8xqXg4iWvM1WwbbQ7CI5/EMk3DhloYBwMyk+Ywtta3dIAIh9sC7llXoKovf3L+w==
-  dependencies:
-    "@babel/runtime" "^7.4.3"
-    dom-testing-library "^4.1.0"
 
 react-tiny-virtual-list@^2.1.4:
   version "2.2.0"
@@ -9833,7 +9833,7 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
-wait-for-expect@^1.1.1:
+wait-for-expect@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.2.0.tgz#fdab6a26e87d2039101db88bff3d8158e5c3e13f"
   integrity sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==


### PR DESCRIPTION
## Descrição
A lib `react-testing-library` mudou de nome e passa a ser chamado de `@testing-library/react`, os motivos estão [aqui](https://github.com/testing-library/react-testing-library/releases/tag/v8.0.0).

Com isso para mantermos o fonte atualizado e com novas features da lib, precisamos atualizar ela, e nessa PR foi isso que foi feito.
