### PR TITLE
Adicionando teste tablist

### DIFF
--- a/src/layouts/__tests__/content.test.js
+++ b/src/layouts/__tests__/content.test.js
@@ -6,7 +6,7 @@ const CONTEUDO = 'Conteúdo';
 
 jest.mock('next/link', () => ({ children }) => children);
 
-describe('Alerta deve', () => {
+describe('Conteúdo layout deve', () => {
   test('renderizar', () => {
     const { container } = render(<Content />);
 
@@ -19,7 +19,7 @@ describe('Alerta deve', () => {
     expect(getByText(CONTEUDO)).toBeInTheDocument();
   });
 
-  test('ter ter node filho', () => {
+  test('ter node filho', () => {
     const { getByText } = render(<Content>{CONTEUDO}</Content>);
 
     expect(getByText(CONTEUDO)).toBeInTheDocument();

--- a/src/layouts/__tests__/contentTablist.test.js
+++ b/src/layouts/__tests__/contentTablist.test.js
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react';
+
+import ContentTablist from '../contentTablist';
+
+const CONTEUDO = 'Conteúdo';
+const ITEMS = [
+  {
+    title: 'Produto',
+    icon: 'projects',
+    tabs: [{ name: 'Produtos da aba', href: '/products' }]
+  }
+];
+
+jest.mock('next/link', () => ({ children }) => children);
+
+describe('Conteúdo Tablist layout deve', () => {
+  test('renderizar', () => {
+    const { container } = render(<ContentTablist />);
+
+    expect(container).toBeInTheDocument();
+  });
+
+  test('ter abas', () => {
+    const { getByText } = render(<ContentTablist items={ITEMS} />);
+
+    expect(getByText('Produtos da aba')).toBeInTheDocument();
+  });
+
+  test('ter node filho', () => {
+    const { getByText } = render(<ContentTablist>{CONTEUDO}</ContentTablist>);
+
+    expect(getByText(CONTEUDO)).toBeInTheDocument();
+  });
+});

--- a/src/layouts/__tests__/page.test.js
+++ b/src/layouts/__tests__/page.test.js
@@ -6,7 +6,7 @@ const CONTEUDO = 'Conteúdo';
 
 jest.mock('next/link', () => ({ children }) => children);
 
-describe('Alerta deve', () => {
+describe('Página layout deve', () => {
   test('renderizar', () => {
     const { container } = render(<Page />);
 
@@ -19,7 +19,7 @@ describe('Alerta deve', () => {
     expect(getByText(CONTEUDO)).toBeInTheDocument();
   });
 
-  test('ter ter node filho', () => {
+  test('ter node filho', () => {
     const { getByText } = render(<Page>{CONTEUDO}</Page>);
 
     expect(getByText(CONTEUDO)).toBeInTheDocument();

--- a/src/layouts/__tests__/pageTablist.test.js
+++ b/src/layouts/__tests__/pageTablist.test.js
@@ -1,0 +1,41 @@
+import { render } from '@testing-library/react';
+
+import PageTablist from '../pageTablist';
+
+const CONTEUDO = 'Conteúdo';
+const TITULO = 'Produtos título';
+const ITEMS = [
+  {
+    title: 'Produto',
+    icon: 'projects',
+    tabs: [{ name: 'Produtos da aba', href: '/products' }]
+  }
+];
+
+jest.mock('next/link', () => ({ children }) => children);
+
+describe('Página Tablist layout deve', () => {
+  test('renderizar', () => {
+    const { container } = render(<PageTablist />);
+
+    expect(container).toBeInTheDocument();
+  });
+
+  test('ter título', () => {
+    const { getByText } = render(<PageTablist title={TITULO} />);
+
+    expect(getByText(TITULO)).toBeInTheDocument();
+  });
+
+  test('ter abas', () => {
+    const { getByText } = render(<PageTablist items={ITEMS} />);
+
+    expect(getByText('Produtos da aba')).toBeInTheDocument();
+  });
+
+  test('ter node filho', () => {
+    const { getByText } = render(<PageTablist>{CONTEUDO}</PageTablist>);
+
+    expect(getByText(CONTEUDO)).toBeInTheDocument();
+  });
+});

--- a/src/layouts/products/__tests__/index.js
+++ b/src/layouts/products/__tests__/index.js
@@ -1,0 +1,101 @@
+import { render } from '@testing-library/react';
+
+import ContainerProducts from '../index';
+
+const CONTEUDO = 'Conteúdo';
+
+jest.mock('next/link', () => ({ children }) => children);
+
+describe('Conteúdo Tablist layout deve', () => {
+  test('renderizar', () => {
+    const { container, debug } = render(<ContainerProducts />);
+    debug();
+    expect(container).toBeInTheDocument();
+  });
+
+  test('ter título', () => {
+    const { getAllByText } = render(<ContainerProducts />);
+
+    expect(
+      getAllByText((_, { textContent }) => textContent === 'Produtos')[1]
+    ).toBeInTheDocument();
+  });
+
+  test('ter aba de produtos', () => {
+    const { getAllByRole } = render(<ContainerProducts />);
+    const [node] = getAllByRole(
+      (_, { textContent }) => textContent === 'Produtos'
+    );
+
+    expect(node.textContent).toBe('Produtos');
+    expect(node.id).toBe('/products');
+  });
+
+  test('ter aba de categorias', () => {
+    const { getAllByRole } = render(<ContainerProducts />);
+    const [node] = getAllByRole(
+      (_, { textContent }) => textContent === 'Categorias'
+    );
+
+    expect(node.textContent).toBe('Categorias');
+    expect(node.id).toBe('/products/categories');
+  });
+
+  test('ter aba de marcas', () => {
+    const { getAllByRole } = render(<ContainerProducts />);
+    const [node] = getAllByRole(
+      (_, { textContent }) => textContent === 'Marcas'
+    );
+
+    expect(node.textContent).toBe('Marcas');
+    expect(node.id).toBe('/products/brands');
+  });
+
+  test('ter aba de estoques', () => {
+    const { getAllByRole } = render(<ContainerProducts />);
+    const [node] = getAllByRole(
+      (_, { textContent }) => textContent === 'Estoques'
+    );
+
+    expect(node.textContent).toBe('Estoques');
+    expect(node.id).toBe('/products/stocks');
+  });
+
+  test('ter aba de validade de produtos', () => {
+    const { getAllByRole } = render(<ContainerProducts />);
+    const [node] = getAllByRole(
+      (_, { textContent }) => textContent === 'Validade de produtos'
+    );
+
+    expect(node.textContent).toBe('Validade de produtos');
+    expect(node.id).toBe('/products/validity');
+  });
+
+  test('ter aba de entrada', () => {
+    const { getAllByRole } = render(<ContainerProducts />);
+    const [node] = getAllByRole(
+      (_, { textContent }) => textContent === 'Entrada'
+    );
+
+    expect(node.textContent).toBe('Entrada');
+    expect(node.id).toBe('/products/input');
+  });
+
+  test('ter aba de saída', () => {
+    const { getAllByRole } = render(<ContainerProducts />);
+    const [node] = getAllByRole(
+      (_, { textContent }) => textContent === 'Saída'
+    );
+
+    expect(node.textContent).toBe('Saída');
+    expect(node.id).toBe('/products/output');
+  });
+
+  test('ter node filho', () => {
+    const { getByText } = render(
+      <ContainerProducts>{CONTEUDO}</ContainerProducts>
+    );
+
+    expect(getByText(CONTEUDO)).toBeInTheDocument();
+  });
+});

--- a/src/layouts/products/index.js
+++ b/src/layouts/products/index.js
@@ -36,7 +36,7 @@ const getTablist = () => {
 
 const ContainerProducts = ({ children }) => {
   return (
-    <PageTablist title="Produto" items={getTablist()}>
+    <PageTablist title="Produtos" items={getTablist()}>
       {children}
     </PageTablist>
   );


### PR DESCRIPTION
## Descrição
- Incluindo teste para o  novo `content` e `page` que usam `tablist` no seu corpo.
- Incluindo teste para o novo `layout` da página de `produtos`.